### PR TITLE
Update GitHub Actions workflow for latest action versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,11 +8,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
-# Ensure only one deployment runs at a time
-concurrency:
-  group: deploy-to-pages
-  cancel-in-progress: true
-
 # Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
@@ -24,13 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install, build, and upload your site
-        uses: withastro/action@v3
+        uses: withastro/action@v6
         # with:
         # path: . # The root location of your Astro project inside the repository. (optional)
-        # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
+        # node-version: 24 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
         # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        # build-cmd: pnpm run build # The command to run to build your site. Runs the package build script/task by default. (optional)
+        # env:
+        # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
 
   deploy:
     needs: build
@@ -41,4 +39,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deployment, primarily focusing on upgrading action versions and removing the concurrency restriction. These changes ensure compatibility with the latest features and improve maintainability.

**Workflow version upgrades:**

* Upgraded `actions/checkout` from version 4 to 6 in the `build` job for improved performance and security.
* Upgraded `withastro/action` from version 3 to 6 in the `build` job, and updated example configuration comments for Node.js and build commands.
* Upgraded `actions/deploy-pages` from version 4 to 5 in the `deploy` job.

**Workflow configuration changes:**

* Removed the `concurrency` configuration, so multiple deployments can now run in parallel if triggered.…nd remove concurrency settings