### PR TITLE
chore: group eslint-related dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+    groups:
+      # eslint and its plugins/tooling must bump together (eslint-plugin-astro 3 requires eslint 10)
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-plugin-*'
+          - '@typescript-eslint/*'
+          - 'typescript-eslint'


### PR DESCRIPTION
## Summary

Groups eslint + its plugins and `@typescript-eslint` packages into a single Dependabot PR.

## Why

Two open Dependabot PRs are interdependent and fail to install individually:
- `eslint` 9 → 10 (#49): blocked because `eslint-plugin-jsx-a11y@6.10.2` only supports eslint ≤ 9.
- `eslint-plugin-astro` 1 → 3 (#48): requires `eslint >=10`.

Grouping lets the whole eslint toolchain upgrade in one coordinated PR that actually resolves.

## Requires

The existing separate PRs (#49, #48) should be closed so Dependabot opens one grouped PR instead.