### PR TITLE
feat: add 7-day cooldown before dependabot auto-merge

### DIFF
--- a/.github/workflows/automerge-scheduled.yml
+++ b/.github/workflows/automerge-scheduled.yml
@@ -1,0 +1,34 @@
+name: Dependabot Auto-merge (cooldown sweep)
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for Dependabot PRs past the cooldown
+        run: |
+          COOLDOWN_DAYS=7
+          prs=$(gh pr list --repo "${GITHUB_REPOSITORY}" --author "app/dependabot" --state open --json number,createdAt --jq -r '.[] | "\(.number) \(.createdAt)"')
+          if [ -z "${prs}" ]; then
+            echo "No open Dependabot PRs"
+            exit 0
+          fi
+          while read -r number created_at; do
+            age_days=$(( ($(date +%s) - $(date -d "${created_at}" +%s)) / 86400 ))
+            if [ "${age_days}" -ge "${COOLDOWN_DAYS}" ]; then
+              echo "Enabling auto-merge on #${number} (age ${age_days}d)"
+              gh pr merge --auto --merge "${number}" || echo "Could not enable auto-merge on #${number}"
+            else
+              echo "Skipping #${number} (age ${age_days}d < ${COOLDOWN_DAYS}d)"
+            fi
+          done <<< "${prs}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -35,8 +35,17 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Enable auto-merge after cooldown period
+        run: |
+          COOLDOWN_DAYS=7
+          created_at="${{ github.event.pull_request.created_at }}"
+          age_days=$(( ($(date +%s) - $(date -d "${created_at}" +%s)) / 86400 ))
+          if [ "${age_days}" -ge "${COOLDOWN_DAYS}" ]; then
+            echo "PR age ${age_days}d, enabling auto-merge"
+            gh pr merge --auto --merge "$PR_URL"
+          else
+            echo "PR age ${age_days}d < ${COOLDOWN_DAYS}d, cooldown not reached, skipping"
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A collection of interactive simulators and demos for computer science concepts.
 
 ## Automated dependency updates
 
-Dependabot PRs are approved and auto-merged once the CI checks pass. For **major version** updates, a comment is left noting the affected packages; they're still merged automatically unless the visual regression check fails.
+Dependabot PRs are approved immediately, then auto-merged once the CI checks pass **and** a 7-day cooldown has elapsed (a supply-chain mitigation: time for compromised npm releases to be pulled before the update lands). For **major version** updates, a comment is left noting the affected packages.
 
 - `tests/visual.spec.ts` runs Playwright visual regression checks against the built site (`astro preview`) and compares it to committed baseline screenshots.
 - `.github/workflows/automerge.yml` approves Dependabot PRs and enables auto-merge for non-major updates.


### PR DESCRIPTION
## Summary

Adds a **7-day cooldown** before Dependabot PRs are auto-merged, as a supply-chain mitigation: compromised npm releases are usually pulled from the registry within days, so the update sits for a week before landing.

## Changes

- **`.github/workflows/automerge.yml`** — approval and the major-version comment still happen immediately, but `gh pr merge --auto` is now gated on the PR being at least 7 days old (so a PR opened today can't merge, even if checks pass).
- **`.github/workflows/automerge-scheduled.yml`** — daily cron (06:00 UTC) sweeps open Dependabot PRs and enables auto-merge for any past the cooldown that had no intervening events.
- **`README.md`** — documents the cooldown.

Note: the cooldown applies to all Dependabot PRs, including security updates. If you'd rather merge known-vulnerability fixes immediately, that can be exempted.