### PR TITLE
chore: 7-day dependabot cooldown via native config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,8 @@ updates:
       # is at least 7 days old (security updates are not affected).
       default-days: 7
     groups:
-      # eslint and its plugins/tooling must bump together (eslint-plugin-astro 3 requires eslint 10)
-      eslint:
+      # All dependencies update together in one grouped PR
+      all:
         patterns:
-          - 'eslint'
-          - 'eslint-plugin-*'
-          - '@typescript-eslint/*'
-          - 'typescript-eslint'
+          - '*'
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+    cooldown:
+      # Supply-chain mitigation: don't propose version updates until a release
+      # is at least 7 days old (security updates are not affected).
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,3 @@ updates:
       all:
         patterns:
           - '*'
-

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ A collection of interactive simulators and demos for computer science concepts.
 
 ## Automated dependency updates
 
-Dependabot PRs are approved and auto-merged once the CI checks pass. For **major version** updates, a comment is left noting the affected packages; they're still merged automatically unless the visual regression check fails.
+Dependabot PRs are approved and auto-merged once the CI checks pass. For **major version** updates, a comment is left noting the affected packages; they're still merged automatically unless the visual regression check fails. Dependabot also applies a **7-day cooldown** before opening version update PRs (a supply-chain mitigation: a release must be at least 7 days old); security updates are not subject to the cooldown.
 
 - `tests/visual.spec.ts` runs Playwright visual regression checks against the built site (`astro preview`) and compares it to committed baseline screenshots.
-- `.github/workflows/automerge.yml` approves Dependabot PRs and enables auto-merge for non-major updates.
+- `.github/workflows/automerge.yml` approves Dependabot PRs and enables auto-merge for all updates (major updates get a comment).
 - The `Visual Regression` check runs **only on Dependabot PRs** and blocks them if the site renders differently from the baselines.
 
 Visual regression checks only run on Dependabot PRs, so other PRs won't be blocked by snapshot mismatches. If any changes are made to the site's appearance, we can add the `update-snapshots` label to the PR making the change to refresh the baselines on CI.


### PR DESCRIPTION
## Summary

Combines the 7-day cooldown and catch-all grouping into Dependabot's native config.

## Changes

- **`.github/dependabot.yml`**:
  - `cooldown.default-days: 7` — version update PRs aren't opened until a release is at least 7 days old (supply-chain mitigation). Security updates are not subject to the cooldown.
  - `groups.all.patterns: ['*']` — all dependency updates land in one grouped PR instead of separate per-package PRs (replaces the eslint pattern-based group).
- **`README.md`** — documents the cooldown and corrects a stale "non-major updates" line.