### PR TITLE
chore: exclude typescript from grouped dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
       all:
         patterns:
           - '*'
+        # typescript gets its own PR: @astrojs/check only supports ^5 || ^6,
+        # so its major bump breaks npm ci for the whole group.
+        exclude-patterns:
+          - 'typescript'
+    ignore:
+      # Remove once @astrojs/check supports the next typescript major.
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'


### PR DESCRIPTION
## Summary

Fixes the grouped Dependabot PR (currently #59) failing on `npm ci` because the `typescript` bump is incompatible with `@astrojs/check` (which only supports `^5 || ^6`).

## Changes

- **`.github/dependabot.yml`**:
  - `groups.all.exclude-patterns: ['typescript']` — typescript gets its own PR, so it can't fail the grouped PR for all other updates.
  - `ignore` — block `version-update:semver-major` for typescript until `@astrojs/check` supports the next major (remove the ignore once it does).

After merge: Dependabot will regenerate #59 without typescript so it can install and auto-merge; the typescript update is handled separately (and ignored until compatible).