### PR TITLE
fix: unblock dependabot group PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,11 @@ updates:
       - dependency-name: 'typescript'
         update-types:
           - 'version-update:semver-major'
+      # eslint 10 can't install until eslint-plugin-jsx-a11y supports it (peer ^3..^9),
+      # and eslint-plugin-astro 3.x requires eslint >=10. Remove when jsx-a11y catches up.
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'eslint-plugin-astro'
+        update-types:
+          - 'version-update:semver-major'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,9 @@ export default defineConfig({
 		baseURL: BASE_URL,
 		viewport: { width: 1280, height: 720 },
 		colorScheme: 'light',
-		reducedMotion: 'reduce',
+		contextOptions: {
+			reducedMotion: 'reduce',
+		},
 		screenshot: 'off',
 		trace: 'retain-on-failure',
 	},


### PR DESCRIPTION
## Summary

Unblocks the two failing Dependabot PRs (#61 grouped, #62 typescript).

## Changes

- **`playwright.config.ts`** — `reducedMotion` belongs in `use.contextOptions`, not directly under `use` (it's a browser-context option). TS 5.4 silently accepted the old form; TS 5.9's stricter excess-property checks flagged it, failing `astro check` on the typescript PR.
- **`.github/dependabot.yml`** — ignore **major** updates for `eslint` and `eslint-plugin-astro` (in addition to `typescript`): eslint 10 can't install until `eslint-plugin-jsx-a11y` supports it (peer `^3..^9`), and `eslint-plugin-astro@3.x` requires eslint ≥10. These stay ignored until the toolchain is mutually compatible.

Verified `tsc -p tsconfig.json --noEmit` passes with `typescript@5.9.3`.

After merge: comment `@dependabot recreate` on #61/#62 so they regenerate with the fixes.